### PR TITLE
feat: support record.key entries

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,11 +7,8 @@ locals {
   records_enabled = module.this.enabled && length(var.records) > 0
   zone_id         = local.zone_enabled ? join("", cloudflare_zone.default.*.id) : (local.zone_exists ? lookup(data.cloudflare_zones.default[0].zones[0], "id") : null)
   records = local.records_enabled ? {
-    for record in flatten(var.records) :
-    format("%s%s",
-      record.name,
-      record.type,
-    ) => record
+    for index, record in flatten(var.records) :
+    try(record.key, format("%s-%s", record.name, record.type)) => record
   } : {}
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "record_hostnames_to_ids" {
   description = "A map of the zone record hostnames to IDs."
   value = {
     for record in cloudflare_record.default :
-    record.hostname => record.id
+    record.hostname => record.id...
     if local.records_enabled
   }
 }


### PR DESCRIPTION
## What

* Addition of the possibility of adding an extra `key` argument to `records` variable to disambiguate specific scenarios where collisions may occur.
* Addition of extra `-` to `records` key generation to better align with rest of the codebase.

## Why

* Currently, we can't specify records that may produce the same id but with different values like the example below (which are valid ones):

```terraform
module "test" {
  source  = "cloudposse/zone/cloudflare"
  version = "0.1.2"

  context            = module.test_label.context
  zone                = "example.com"
  zone_enabled = false
  enabled           = true
  records            = [
   {
      name    = "@"
      priority  = 1
      ttl          = 1
      type      = "MX"
      value    = "a.example.com"
    },
    {
      name     = "@"
      priority   = 5
      ttl           = 1
      type       = "MX"
      value     = "b.example.com"
    },
  ]
}
```

This PR changes this with the addition of a `key` resource:

```terraform
module "test" {
  source  = "cloudposse/zone/cloudflare"
  version = "0.1.2"

  context            = module.test_label.context
  zone                = "example.com"
  zone_enabled = false
  enabled           = true
  records            = [
   {
      key        = "@-MX-1"
      name     = "@"
      priority   = 1
      ttl           = 1
      type       = "MX"
      value     = "a.example.com"
    },
    {
      key        = "@-MX-2"
      name     = "@"
      priority   = 5
      ttl           = 1
      type       = "MX"
      value     = "b.example.com"
    },
  ]
}
```

The `key` can be applied optionally to the records that needs them. It doesn't force to define one in all records. 

## References

* Closes #15 

