### PR TITLE
Add documentaton for "key" property

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,8 @@ variable "records" {
     proxied:
       Whether the record gets Cloudflare's origin protection.
       Default value: false.
+    key:
+      Specify resource name to be used by Cloudflare resource. Defaults to automatic value.
   DOC
 }
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Document using "key":
- https://github.com/cloudposse/terraform-cloudflare-zone/blob/c464ebf797e1dd8283c8c5f85e703ea82377338b/main.tf#L11

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Default terraform resource name is based on value. I wouldn't want that for CNAMEs. The workaround is to specify fixed `key` for those records.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
