### PR TITLE
temp: pin cloudflare provider version to 4

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 4.0"
+      version = "~> 4"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## Details
- A new cloudflare provider version had released around 14h ago which contains brunch of breaking changes
- We would need to pin the version to 4.X for keeping the module working before its ready to upgrade

## Ref
- https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/guides/version-5-upgrade
