### PR TITLE
Stick to the v4 cloudflare provider, as v5 introduces breaking changes

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 4.0"
+      version = "~> 4.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## what

This PR updates the required providers section to stick to v4 for the cloudflare provider.

## why

Two weeks ago, Cloudflare released their [v5 provider](https://github.com/cloudflare/terraform-provider-cloudflare/releases/tag/v5.0.0), which is a complete rewrite and not backwards compatible with modules that used to work with the v4 provider, including this module.

Without this PR's change, a fresh plan will download the latest v5 provider, and fail with errors like:

```
│ Error: Unsupported block type
│
│   on main.tf line 18, in data "cloudflare_zones" "default":
│   18:   filter {
│
│ Blocks of type "filter" are not expected here.
╵
╷
│ Error: Missing required argument
│
│   on main.tf line 23, in resource "cloudflare_zone" "default":
│   23: resource "cloudflare_zone" "default" {
│
│ The argument "account" is required, but no definition was found.
╵
╷
│ Error: Missing required argument
│
│   on main.tf line 23, in resource "cloudflare_zone" "default":
│   23: resource "cloudflare_zone" "default" {
│
│ The argument "name" is required, but no definition was found.
```

This PR fixes the version such that it'll stick to the v4 provider. `4.52.0`, the last v4 version is confirmed to still work.

Going forward, making this module work with the v5 provider will likely require a refactor.

## references

https://github.com/cloudflare/terraform-provider-cloudflare/releases/tag/v5.0.0
